### PR TITLE
Fix: --help summary for subcommands shows parents summary

### DIFF
--- a/spec/formatter_spec.cr
+++ b/spec/formatter_spec.cr
@@ -15,7 +15,18 @@ private class GreetCommand < Cling::MainCommand
   end
 end
 
+class WelcomeCommand < Cling::Command
+  def setup : Nil
+    @name = "welcome"
+    @summary = @description = "sends a friendly welcome message"
+  end
+
+  def run(arguments : Cling::Arguments, options : Cling::Options) : Nil
+  end
+end
+
 command = GreetCommand.new
+command.add_command WelcomeCommand.new
 formatter = Cling::Formatter.new
 
 describe Cling::Formatter do
@@ -25,6 +36,9 @@ describe Cling::Formatter do
 
     Usage:
     \tgreet <arguments> [options]
+
+    Commands:
+    \twelcome    sends a friendly welcome message
 
     Arguments:
     \tname    the name of the person (required)
@@ -44,6 +58,9 @@ describe Cling::Formatter do
 
     Usage:
     \tgreet <arguments> [options]
+
+    Commands:
+    \twelcome    sends a friendly welcome message
 
     Arguments:
     \tname    the name of the person (required)

--- a/src/cling/formatter.cr
+++ b/src/cling/formatter.cr
@@ -97,7 +97,7 @@ module Cling
       io << "Commands:"
       commands.each do |cmd|
         io << "\n\t"
-        if summary = command.summary
+        if summary = cmd.summary
           cmd.name.ljust(io, max_space, ' ')
           io << summary
         else


### PR DESCRIPTION
A regression slipped through here https://github.com/devnote-dev/cling/commit/b03b7f45d94bfccd07438fd1604fbb577ac939b9#diff-45901be25b8751956836db23748983233566901600112a2ce1c058633d245c0dL89 where when showing the help template subcommands would show the summary of the parent rather than their own defined summaries

Using the "greet" example with a summary added for `MainCommand` and `WelcomeCommand`
#### greet.cr
```cr
require "../../src/cling"
require "./welcome_command"

class MainCommand < Cling::Command
  def setup : Nil
    @name = "greet"
    @summary = @description = "Greets a person"
    add_argument "name", description: "the name of the person to greet", required: true
    add_option 'c', "caps", description: "greet with capitals"
    add_option 'h', "help", description: "sends help information"
  end

  def pre_run(arguments : Cling::Arguments, options : Cling::Options) : Bool
    if options.has? "help"
      puts help_template # generated using Cling::Formatter

      false
    else
      true
    end
  end

  def run(arguments : Cling::Arguments, options : Cling::Options) : Nil
    message = "Hello, #{arguments.get("name")}!"

    if options.has? "caps"
      puts message.upcase
    else
      puts message
    end
  end
end

main = MainCommand.new
main.add_command WelcomeCommand.new

main.execute ARGV
```
#### welcome_command.cr
```cr
class WelcomeCommand < Cling::Command
  def setup : Nil
    @name = "welcome"
    @summary = @description = "sends a friendly welcome message"

    add_argument "name", description: "the name of the person to greet", required: true
    # this will inherit the header and footer properties
    @inherit_borders = true
    # this will NOT inherit the parent flag options
    @inherit_options = false
    # this will inherit the input, output and error IO streams
    @inherit_streams = true
  end

  def pre_run(arguments : Cling::Arguments, options : Cling::Options) : Bool
    if options.has? "help"
      puts help_template # generated using Cling::Formatter

      false
    else
      true
    end
  end

  def run(arguments : Cling::Arguments, options : Cling::Options) : Nil
    stdout.puts "Welcome to the CLI world, #{arguments.get("name")}!"
  end
end
```

### Main
<img width="546" alt="image" src="https://github.com/devnote-dev/cling/assets/13454550/8885b928-af53-43c3-9944-6976168e2317">

### This branch
<img width="549" alt="image" src="https://github.com/devnote-dev/cling/assets/13454550/18875332-a625-4b86-9679-bb12727d47f5">

I opted to update existing formatter specs but if you'd prefer to have new specs in a separate file I'd be more than happy to make the change :~)